### PR TITLE
[FIX] remove unnecessary header includes

### DIFF
--- a/src/main/cpp/MSNumpress.cpp
+++ b/src/main/cpp/MSNumpress.cpp
@@ -17,10 +17,6 @@
    limitations under the License.
  */
 
-#include <stdio.h>
-#include <stdint.h>
-#include <stdexcept>
-#include <vector>
 #include <iostream>
 #include <cmath>
 #include "MSNumpress.hpp"


### PR DESCRIPTION
```
- stdint.h is not available with MSVS2008 and apparently not necessary
  in the code. None of the typdefs found in stdint.h are found in the
  code, it should be safe to delete the include.
- stdio is not used, vector is already declared in the .h file,
  stdexcept is also not used
```
