### PR TITLE
[FIX] bugfix for encodeSlof

### DIFF
--- a/src/main/cpp/MSNumpress.cpp
+++ b/src/main/cpp/MSNumpress.cpp
@@ -713,7 +713,7 @@ void encodeSlof(
 		double fixedPoint
 ) {
 	size_t dataSize = data.size();
-	result.resize(dataSize * 2);
+	result.resize(dataSize * 2 + 8);
 	size_t encodedLength = encodeSlof(&data[0], dataSize, &result[0], fixedPoint);
 	result.resize(encodedLength);
 }


### PR DESCRIPTION
- the maximal length calculated for the vector in encodeSlof is 8 bytes
  too short: it should be 8 bytes + 2 \* dataSize

I think this fixes a bug that I encountered when testing this function (this
code is not tested):

```
std::vector<double> data;
std::vector<unsigned char> encoded;
data[0]  = 100.0;
data[1]  = 200.0;
data[2]  = 300.00005;
data[4]  = 400.00010;

encodeSlof(data, encoded, 10000)
```

instead of encoding the data, it produced a result with zeros instead of the
data. So the encoding was wrong in this case. Additionally, because of faulty
resizing, it wrote to memory which were not previously allocated ( I did not
check this explicitly). So it seems that it writes 8 bytes past the allocated
memory on the stack, e.g. a stack buffer overflow.
