### PR TITLE
Feature/linear fp

### DIFF
--- a/src/main/cpp/MSNumpress.cpp
+++ b/src/main/cpp/MSNumpress.cpp
@@ -135,6 +135,17 @@ static void encodeInt(
 
 /**
  * Decodes an int from the half bytes in bp. Lossless reverse of encodeInt 
+ *
+ * @param data ptr to the char data to decode
+ * @param di position in the char data array to start decoding (will be advanced)
+ * @param max_di size of data array 
+ * @param half helper variable (do not change between multiple calls)
+ * @param res result (a 32 bit integer)
+ *
+ * @note the helper variable indicates whether we look at the first half byte
+ * or second half byte of the current data (thus whether to interpret the first
+ * half byte of data[*di] or the second half byte).
+ *
  */
 static void decodeInt(
 		const unsigned char *data,
@@ -148,6 +159,10 @@ static void decodeInt(
     unsigned char head;
     unsigned char hb;
 
+	// Extract the first half byte, specifying the number of leading zero half
+	// bytes of the final integer.
+	// If half is zero, we look at the first half byte, otherwise we look at
+	// the second (lower) half byte and advance the counter to the next char.
 	if (*half == 0) {
 		head = data[*di] >> 4;
 	} else {
@@ -155,12 +170,12 @@ static void decodeInt(
 		(*di)++;
 	}
 
-	*half = 1-(*half);
+	*half = 1-(*half); // switch to other half byte
 	*res = 0;
 	
 	if (head <= 8) {
 		n = head;
-	} else { // leading ones, fill n half bytes in res
+	} else { // we have n leading ones, fill n half bytes in res with 0xf
 		n = head - 8;
 		mask = 0xf0000000;
 		for (i=0; i<n; i++) {

--- a/src/main/cpp/MSNumpress.cpp
+++ b/src/main/cpp/MSNumpress.cpp
@@ -194,6 +194,26 @@ static void decodeInt(
 
 /////////////////////////////////////////////////////////////
 
+double optimalLinearFixedPointMass(
+		const double *data, 
+		size_t dataSize,
+        double mass_acc
+) {
+	if (dataSize < 3) return 0; // we just encode the first two points as floats
+
+    // We calculate the maximal fixedPoint we need to achieve a specific mass
+    // accuracy. Note that the maximal error we will make by encoding as int is
+    // 0.5 due to rounding errors.
+    double maxFP = 0.5 / mass_acc;
+
+    // There is a maximal value for the FP given by the int length (32bit)
+    // which means we cannot choose a value higher than that. In case we cannot
+    // achieve the desired accuracy, return failure (-1).
+    double maxFP_overflow = optimalLinearFixedPoint(data, dataSize);
+    if (maxFP > maxFP_overflow) return -1;
+
+    return maxFP;
+}
 
 double optimalLinearFixedPoint(
 		const double *data, 

--- a/src/main/cpp/MSNumpress.hpp
+++ b/src/main/cpp/MSNumpress.hpp
@@ -55,10 +55,37 @@ namespace numpress {
 
 namespace MSNumpress {
 	
+	/**
+	 * Compute the maximal linear fixed point that prevents integer overflow.
+     *
+	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
+	 * @dataSize	number of doubles from *data to encode
+     *
+	 * @return		the linear fixed point safe to use
+	 */
 	double optimalLinearFixedPoint(
 		const double *data, 
 		size_t dataSize);
 	
+	/**
+	 * Compute the optimal linear fixed point with a desired m/z accuracy.
+     *
+     * @note If the desired accuracy cannot be reached without overflowing 64
+     * bit integers, then a negative value is returned. You need to check for
+     * this and in that case abandon numpress or use optimalLinearFixedPoint
+     * which returns the largest safe value.
+     *
+	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
+	 * @dataSize	number of doubles from *data to encode
+	 * @mass_acc	desired m/z accuracy in Th
+     *
+	 * @return		the linear fixed point that satisfies the accuracy requirement (or -1 in case of failure).
+	 */
+    double optimalLinearFixedPointMass(
+            const double *data, 
+            size_t dataSize,
+            double mass_acc);
+
 	/**
 	 * Encodes the doubles in data by first using a 
 	 *   - lossy conversion to a 4 byte 5 decimal fixed point representation

--- a/src/main/cpp/MSNumpress.hpp
+++ b/src/main/cpp/MSNumpress.hpp
@@ -57,10 +57,10 @@ namespace MSNumpress {
 	
 	/**
 	 * Compute the maximal linear fixed point that prevents integer overflow.
-     *
+	 *
 	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
 	 * @dataSize	number of doubles from *data to encode
-     *
+	 *
 	 * @return		the linear fixed point safe to use
 	 */
 	double optimalLinearFixedPoint(
@@ -69,22 +69,22 @@ namespace MSNumpress {
 	
 	/**
 	 * Compute the optimal linear fixed point with a desired m/z accuracy.
-     *
-     * @note If the desired accuracy cannot be reached without overflowing 64
-     * bit integers, then a negative value is returned. You need to check for
-     * this and in that case abandon numpress or use optimalLinearFixedPoint
-     * which returns the largest safe value.
-     *
+	 *
+	 * @note If the desired accuracy cannot be reached without overflowing 64
+	 * bit integers, then a negative value is returned. You need to check for
+	 * this and in that case abandon numpress or use optimalLinearFixedPoint
+	 * which returns the largest safe value.
+	 *
 	 * @data		pointer to array of double to be encoded (need memorycont. repr.)
 	 * @dataSize	number of doubles from *data to encode
 	 * @mass_acc	desired m/z accuracy in Th
-     *
+	 *
 	 * @return		the linear fixed point that satisfies the accuracy requirement (or -1 in case of failure).
 	 */
-    double optimalLinearFixedPointMass(
-            const double *data, 
-            size_t dataSize,
-            double mass_acc);
+	double optimalLinearFixedPointMass(
+		const double *data,
+		size_t dataSize,
+		double mass_acc);
 
 	/**
 	 * Encodes the doubles in data by first using a 

--- a/src/main/cpp/MSNumpressTest.cpp
+++ b/src/main/cpp/MSNumpressTest.cpp
@@ -121,7 +121,7 @@ void decodeLinearNiceLowFP() {
   mzs[6] = 700.00010;
   
   size_t nMzs = 7;
-  unsigned char encoded[28];
+  unsigned char encoded[33]; // max length is 33 bytes
 
   // check for fixed points
   {
@@ -158,15 +158,15 @@ void decodeLinearNiceLowFP() {
     assert(abs(400.00010 - decoded[3]) < 0.001);
   }
   
-  double mz_err[7];
-  double encodedLength[7];
+  double mz_err[5];
+  double encodedLength[5];
 
   // for higher accuracy, we get longer encoded lengths
   mz_err[0] = 0.1;  encodedLength[0] = 22;
   mz_err[1] = 1e-3; encodedLength[1] = 25;
   mz_err[2] = 1e-5; encodedLength[2] = 29;
   mz_err[3] = 1e-6; encodedLength[3] = 30;
-  mz_err[3] = 1e-7; encodedLength[3] = 31;
+  mz_err[4] = 1e-7; encodedLength[4] = 31;
 
   for (int k = 0; k < 4; k++)
   {

--- a/src/main/python/MSNumpress.pxd
+++ b/src/main/python/MSNumpress.pxd
@@ -22,6 +22,11 @@ from libcpp.vector cimport vector as libcpp_vector
 
 cdef extern from "MSNumpress.hpp" namespace "ms::numpress::MSNumpress":
 
+    double optimalLinearFixedPointMass(
+        double *data, 
+        size_t dataSize,
+        double mass_acc)
+
     double optimalLinearFixedPoint(
         double *data, 
         size_t dataSize)

--- a/src/main/python/PyMSNumpress.pyx
+++ b/src/main/python/PyMSNumpress.pyx
@@ -23,12 +23,21 @@ from cython.operator cimport dereference as deref, preincrement as inc, address 
 from MSNumpress cimport encodeLinear as _encodeLinear
 from MSNumpress cimport decodeLinear as _decodeLinear
 from MSNumpress cimport optimalLinearFixedPoint as _optimalLinearFixedPoint
+from MSNumpress cimport optimalLinearFixedPointMass as _optimalLinearFixedPointMass
 from MSNumpress cimport encodeSlof as _encodeSlof
 from MSNumpress cimport decodeSlof as _decodeSlof
 from MSNumpress cimport optimalSlofFixedPoint as _optimalSlofFixedPoint
 from MSNumpress cimport encodePic as _encodePic
 from MSNumpress cimport decodePic as _decodePic
 
+
+def optimalLinearFixedPointMass(data, mz):
+    dataSize = len(data)
+    cdef libcpp_vector[double] c_data = data
+
+    cdef double result = _optimalLinearFixedPointMass( &c_data[0], dataSize, mz)
+
+    return result
 
 def optimalLinearFixedPoint(data):
     dataSize = len(data)

--- a/src/main/python/test_pymsnumpress.py
+++ b/src/main/python/test_pymsnumpress.py
@@ -123,6 +123,8 @@ class TestMSNumpress(unittest.TestCase):
     def test_optimalLinearFixedPointMass(self):
         pt = PyMSNumpress.optimalLinearFixedPointMass(self.data, 0.001)
         self.assertAlmostEqual(pt, 500.0)
+        pt = PyMSNumpress.optimalLinearFixedPointMass(self.data, 1e-10)
+        self.assertAlmostEqual(pt, -1)
 
     def test_encodeSlof(self):
 

--- a/src/main/python/test_pymsnumpress.py
+++ b/src/main/python/test_pymsnumpress.py
@@ -76,6 +76,10 @@ class TestMSNumpress(unittest.TestCase):
         pt = PyMSNumpress.optimalLinearFixedPoint(self.data)
         self.assertAlmostEqual(pt, 21262214.0)
 
+    def test_optimalLinearFixedPointMass(self):
+        pt = PyMSNumpress.optimalLinearFixedPointMass(self.data, 0.001)
+        self.assertAlmostEqual(pt, 500.0)
+
     def test_encodeSlof(self):
 
         result = []

--- a/src/main/python/test_pymsnumpress.py
+++ b/src/main/python/test_pymsnumpress.py
@@ -35,6 +35,15 @@ class TestMSNumpress(unittest.TestCase):
             300.00005,
             400.00010,
         ]
+        self.data_long = [ 
+            100.0,
+            200.0,
+            300.00005,
+            400.00010,
+	    450.00010,
+	    455.00010,
+	    700.00010
+        ]
         self.fp_slof = 10000
         self.linear_result = [64, 248, 106, 0, 0, 0, 0, 0, 128, 150, 152, 0, 32, 29, 154, 0, 136]
 
@@ -47,6 +56,41 @@ class TestMSNumpress(unittest.TestCase):
         self.assertEqual(result[0], 64)
         self.assertEqual(result, self.linear_result)
 
+        result = []
+        PyMSNumpress.encodeLinear(self.data_long,result,5.0)
+        self.assertEqual(len(result), 22)
+
+        result = []
+        PyMSNumpress.encodeLinear(self.data_long,result,500.0)
+        self.assertEqual(len(result), 25)
+
+        result = []
+        PyMSNumpress.encodeLinear(self.data_long,result,5e4)
+        self.assertEqual(len(result), 29)
+
+        result = []
+        PyMSNumpress.encodeLinear(self.data_long,result,5e5)
+        self.assertEqual(len(result), 30)
+
+        result = []
+        PyMSNumpress.encodeLinear(self.data_long,result,5e6)
+        self.assertEqual(len(result), 31)
+
+        # accurate to 3 sign digits
+        result = []
+        decoded = []
+        PyMSNumpress.encodeLinear(self.data_long,result,500.0)
+        PyMSNumpress.decodeLinear(result, decoded)
+
+        self.assertAlmostEqual(decoded[0], 100, 3)
+        self.assertAlmostEqual(decoded[1], 200, 3)
+        self.assertAlmostEqual(decoded[2], 300, 3)
+        self.assertAlmostEqual(decoded[3], 400.00010, 3)
+        self.assertAlmostEqual(decoded[4], 450.00010, 3)
+        self.assertAlmostEqual(decoded[5], 455.00010, 3)
+        self.assertAlmostEqual(decoded[6], 700.00010, 3)
+
+	    
     def test_decodeLinear(self):
 
         result = []


### PR DESCRIPTION
Add a small function for outside clients to compute a linear fixed point. Instead of computing the maximal possible fixpoint, this computes the minimal fixpoint to achieve the desired mass accuracy. 

Using this function results in substantially smaller file sizes. I observe 70% smaller files in some instances by simply changing this parameter from the maximal accuracy to ca 1 ppm accuracy @ 150 mass-to-charge (which is about 0.5 ppm accuracy at 300 m/z). This is more than sufficient for most TOF data and brings down the file sizes substantially:

As a test file I use the file `olgas_K121026_001_SW_Wayne_R1_d00.wiff` from the Schubert et al [1,2]:

```
-rw-rw-r-- 1 hr   hr   8.6M Dec  6  2015 olgas_K121026_001_SW_Wayne_R1_d00.wiff
-rw-rw-r-- 1 hr   hr   3.5G Dec  6  2015 olgas_K121026_001_SW_Wayne_R1_d00.wiff.scan
```

when using a regular converter to mzML, I end up with a file of about 15 GB size in profile mode (no numpress compression but `.gz` on the file). Applying the currently implemented conversion in proteowizard / OpenMS with the "maximal" fixed point results in a file of 5.6 GB size (using `.gz`) but when specifying 1ppm accuracy at either 150 m/z or 400 m/z, the file size goes down to 3.1 to 3.3 GB:

```
-rw-r--r-- 1 hr hr    15G Mar  3 22:28 olgas_K121026_001_SW_Wayne_R1_d00.wiff.profile.mzML.gz
-rw-rw-r-- 1 hr hr   5.6G Mar  7 18:37 olgas_K121026_001_SW_Wayne_R1_d00.wiff.profile.compress.mzML.gz
-rw-rw-r-- 1 hr hr   3.3G Mar  8 14:03 olgas_K121026_001_SW_Wayne_R1_d00.wiff.profile.lc_1ppm_150.mzML.gz
-rw-rw-r-- 1 hr hr   3.1G Mar  8 13:02 olgas_K121026_001_SW_Wayne_R1_d00.wiff.profile.lc_1ppm_400.mzML.gz
```

Including this function allows client to request a fixed point that minimizes file size while at the same time preserving a desired accuracy. While the computation is trivial, the interface makes it easier for clients to get a guarantee for the specific accuracy and the client does not have to understand how the fixed Point is calculated. 

Basically, this PR will allow clients to reduce their file sizes by a large amount by choosing appropriate parameters.

Ref

1. http://www.biorxiv.org/content/early/2016/03/18/044552
2. http://www.peptideatlas.org/PASS/PASS00779
